### PR TITLE
Features to allow putting arduino to sleep between packets

### DIFF
--- a/src/LoRa.cpp
+++ b/src/LoRa.cpp
@@ -76,7 +76,7 @@ LoRaClass::LoRaClass() :
   setTimeout(0);
 }
 
-int LoRaClass::begin(long frequency)
+int LoRaClass::begin(long frequency, boolean reset)
 {
 #if defined(ARDUINO_SAMD_MKRWAN1300) || defined(ARDUINO_SAMD_MKRWAN1310)
   pinMode(LORA_IRQ_DUMB, OUTPUT);
@@ -103,11 +103,13 @@ int LoRaClass::begin(long frequency)
   if (_reset != -1) {
     pinMode(_reset, OUTPUT);
 
-    // perform reset
-    digitalWrite(_reset, LOW);
-    delay(10);
-    digitalWrite(_reset, HIGH);
-    delay(10);
+    if (reset) {
+      // perform reset
+      digitalWrite(_reset, LOW);
+      delay(10);
+      digitalWrite(_reset, HIGH);
+      delay(10);
+    }
   }
 
   // start SPI
@@ -117,6 +119,11 @@ int LoRaClass::begin(long frequency)
   uint8_t version = readRegister(REG_VERSION);
   if (version != 0x12) {
     return 0;
+  }
+
+  if (!reset) {
+    // did not reset the LoRa chip so no need to set it up again.
+    return 1;
   }
 
   // put in sleep mode
@@ -177,7 +184,6 @@ int LoRaClass::beginPacket(int implicitHeader)
 
 int LoRaClass::endPacket(bool async)
 {
-  
   if ((async) && (_onTxDone))
       writeRegister(REG_DIO_MAPPING_1, 0x40); // DIO0 => TXDONE
 

--- a/src/LoRa.h
+++ b/src/LoRa.h
@@ -21,7 +21,7 @@
 #define LORA_DEFAULT_DIO0_PIN      LORA_IRQ
 #else
 #define LORA_DEFAULT_SPI           SPI
-#define LORA_DEFAULT_SPI_FREQUENCY 8E6 
+#define LORA_DEFAULT_SPI_FREQUENCY 8E6
 #define LORA_DEFAULT_SS_PIN        10
 #define LORA_DEFAULT_RESET_PIN     9
 #define LORA_DEFAULT_DIO0_PIN      2
@@ -34,7 +34,7 @@ class LoRaClass : public Stream {
 public:
   LoRaClass();
 
-  int begin(long frequency);
+  int begin(long frequency, boolean reset = true);
   void end();
 
   int beginPacket(int implicitHeader = false);
@@ -76,8 +76,10 @@ public:
   void disableCrc();
   void enableInvertIQ();
   void disableInvertIQ();
-  
+
   void setOCP(uint8_t mA); // Over Current Protection control
+
+  void handleDio0Rise();
 
   // deprecated
   void crc() { enableCrc(); }


### PR DESCRIPTION
These changes allow use of the esp32's deep sleep mode between packets. There is a new argument to the `begin()` method to indicate if the chip should be reset. It defaults to `true` (the previous behavior), so the API won't break.

Additionally, `handleDio0Rise()` has been made public, so it can be called by the main program when it is booted up from the pin rising.